### PR TITLE
Simple menu for windows

### DIFF
--- a/source/frontends/sdl/imgui/sdlimguiframe.cpp
+++ b/source/frontends/sdl/imgui/sdlimguiframe.cpp
@@ -258,7 +258,46 @@ void SDLImGuiFrame::RenderPresent()
   ImGui_ImplSDL2_NewFrame(myWindow.get());
   ImGui::NewFrame();
 
-  ShowSettings();
+  // Really simple menu to demonstrate Imgui methods
+  // (uses same menu item to open and close windows)
+  if (ImGui::BeginMainMenuBar())
+  {
+    if (ImGui::BeginMenu("File"))
+    {
+      if (ImGui::MenuItem("Settings", "")) {
+        if (mySettings.showSettings) {
+          mySettings.showSettings = false;
+        } else {
+          mySettings.showSettings = true;
+        }
+      }
+      if (ImGui::MenuItem("Demo", "")) {
+        if (mySettings.showDemo) {
+          mySettings.showDemo = false;
+        } else {
+          mySettings.showDemo = true;
+        }
+      }
+      ImGui::EndMenu();
+    }
+
+    if (ImGui::BeginMenu("Edit"))
+    {
+      if (ImGui::MenuItem("Undo", "CTRL+Z")) {}
+      if (ImGui::MenuItem("Redo", "CTRL+Y", false, false)) {}  // Disabled item
+      ImGui::Separator();
+      if (ImGui::MenuItem("Cut", "CTRL+X")) {}
+      if (ImGui::MenuItem("Copy", "CTRL+C")) {}
+      if (ImGui::MenuItem("Paste", "CTRL+V")) {}
+      ImGui::EndMenu();
+    }
+    ImGui::EndMainMenuBar();
+  }
+
+  if (mySettings.showSettings)
+  {
+	ShowSettings();
+  }
 
   if (mySettings.showDemo)
   {


### PR DESCRIPTION
This provides a slightly nicer way of opening Settings window so it doesn't always have to be displayed. Mainly to demonstrate basic method.

Note: This currently overlays the emulator render area. Render area will need to be offset by the number of pixels matching menu height.