### PR TITLE
sa2: do not call VideoPresentScreen every Apple ][ frame when in full…

### DIFF
--- a/source/frontends/sdl/main.cpp
+++ b/source/frontends/sdl/main.cpp
@@ -155,8 +155,9 @@ void run_sdl(int argc, const char * argv [])
       frame->ExecuteOneFrame(oneFrame);
       cpuTimer.toc();
 
-      if (!options.headless)
+      if (!options.headless && !g_bFullSpeed)
       {
+        // in full speed VideoRedrawScreenDuringFullSpeed is called inside SDLFrame::Execute
         refreshScreenTimer.tic();
         frame->VideoPresentScreen();
         refreshScreenTimer.toc();

--- a/source/frontends/sdl/sdlframe.cpp
+++ b/source/frontends/sdl/sdlframe.cpp
@@ -591,8 +591,9 @@ namespace sa2
         g_dwCyclesThisFrame -= dwClksPerFrame;
         if (g_bFullSpeed)
         {
-          NTSC_VideoClockResync(g_dwCyclesThisFrame);
-          GetVideo().VideoRefreshBuffer(GetVideo().GetVideoMode(), true);
+          // only call VideoPresentScreen every 16ms
+          // hardcoded in FrameBase::VideoRedrawScreenDuringFullSpeed()
+          VideoRedrawScreenDuringFullSpeed(g_dwCyclesThisFrame);
         }
       }
     } while (totalCyclesExecuted < cyclesToExecute);
@@ -687,6 +688,7 @@ namespace sa2
         // entering full speed
         MB_Mute();
         setGLSwapInterval(0);
+        VideoRedrawScreenDuringFullSpeed(0, true);
       }
       else
       {


### PR DESCRIPTION
… speed.

But only call it after 16ms wall clock.

Fixes https://github.com/audetto/AppleWin/issues/61

Signed-off-by: Andrea Odetti <mariofutire@gmail.com>