### PR TITLE
Remove leftovers from recent upstream merge

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -183,8 +183,6 @@ set(HEADER_FILES
   DiskDefs.h
   DiskLog.h
   Interface.h
-  SaveState_Structs_common.h
-  SaveState_Structs_v1.h
 
   Debugger/Debug.h
   Debugger/DebugDefs.h


### PR DESCRIPTION
I assume these are leftovers in the cmake file as they are no longer present in the sources from upstream.

After removal the libretro build works again.