### PR TITLE
fix Xcode build issues

### DIFF
--- a/source/Uthernet2.cpp
+++ b/source/Uthernet2.cpp
@@ -27,7 +27,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Tfe/IPRaw.h"
 #include "Tfe/DNS.h"
 #include "W5100.h"
-#include "../Registry.h"
+#include "Registry.h"
 
 
 // Virtual DNS

--- a/source/linux/duplicates/Registry.cpp
+++ b/source/linux/duplicates/Registry.cpp
@@ -1,5 +1,8 @@
 #include "StdAfx.h"
 #include "Registry.h"
+#include "Common.h"
+#include "Card.h"
+#include "CopyProtectionDongles.h"
 
 
 


### PR DESCRIPTION
- explicit #includes
- fix include path

These were caught by the macOS Xcode build, which I had previously #ifdef'ed to fix. I've tested these against the sa2 build for macOS, but I don't have a Linux box handy to verify.