### PR TITLE
avoid mixing unsigned and signed arithmetic,

### DIFF
--- a/source/frontends/common2/speed.cpp
+++ b/source/frontends/common2/speed.cpp
@@ -48,7 +48,7 @@ namespace common2
     }
     else
     {
-      const uint64_t currentCycles = g_nCumulativeCycles;
+      const int64_t currentCycles = g_nCumulativeCycles;
       const auto currentTime = std::chrono::steady_clock::now();
 
       const auto currentDelta = std::chrono::duration_cast<std::chrono::microseconds>(currentTime - myStartTime).count();
@@ -58,7 +58,7 @@ namespace common2
       // permanently apply the correction
       myStartCycles += g_nCpuCyclesFeedback;
 
-      const uint64_t targetCycles = static_cast<uint64_t>(targetDeltaInMicros * myAudioSpeed * 1.0e-6) + myStartCycles;
+      const int64_t targetCycles = static_cast<int64_t>(targetDeltaInMicros * myAudioSpeed * 1.0e-6) + myStartCycles;
       if (targetCycles > currentCycles)
       {
         // number of cycles to fill this period

--- a/source/frontends/common2/speed.h
+++ b/source/frontends/common2/speed.h
@@ -33,8 +33,8 @@ namespace common2
     const bool myFixedSpeed;
 
     std::chrono::time_point<std::chrono::steady_clock> myStartTime;
-    uint64_t myStartCycles;
-    uint64_t myOrgStartCycles;
+    int64_t myStartCycles;
+    int64_t myOrgStartCycles;
     double myAudioSpeed;
 
     int64_t myTotalFeedbackCycles;


### PR DESCRIPTION
…because a negative `g_nCuuCyclesFeedback` causes `cyclesToExecute` to become a massive positive number

https://github.com/audetto/AppleWin/issues/98