### PR TITLE
Make IDirectSoundBuffer::Unlock() virtual

### DIFF
--- a/source/linux/libwindows/dsound.h
+++ b/source/linux/libwindows/dsound.h
@@ -113,7 +113,7 @@ public:
   HRESULT GetCurrentPosition( LPDWORD lpdwCurrentPlayCursor, LPDWORD lpdwCurrentWriteCursor );
 
   HRESULT Lock( DWORD dwWriteCursor, DWORD dwWriteBytes, LPVOID * lplpvAudioPtr1, DWORD * lpdwAudioBytes1, LPVOID * lplpvAudioPtr2, DWORD * lpdwAudioBytes2, DWORD dwFlags );
-  HRESULT Unlock( LPVOID lpvAudioPtr1, DWORD dwAudioBytes1, LPVOID lpvAudioPtr2, DWORD dwAudioBytes2 );
+  virtual HRESULT Unlock( LPVOID lpvAudioPtr1, DWORD dwAudioBytes1, LPVOID lpvAudioPtr2, DWORD dwAudioBytes2 );
 
   virtual HRESULT Stop();
   virtual HRESULT Play( DWORD dwReserved1, DWORD dwReserved2, DWORD dwFlags );


### PR DESCRIPTION
- macOS implementation needs to override this in order to send the audio output for recording