### PR TITLE
remove const from Paddle instance

### DIFF
--- a/source/linux/paddle.cpp
+++ b/source/linux/paddle.cpp
@@ -13,7 +13,7 @@ namespace
 }
 
 
-std::shared_ptr<const Paddle> Paddle::instance;
+std::shared_ptr<Paddle> Paddle::instance;
 
 std::set<int> Paddle::ourButtons;
 bool Paddle::ourSquaring = true;

--- a/source/linux/paddle.h
+++ b/source/linux/paddle.h
@@ -22,7 +22,7 @@ public:
   static std::set<int> ourButtons;
   static void setSquaring(bool value);
 
-  static std::shared_ptr<const Paddle> instance;
+  static std::shared_ptr<Paddle> instance;
 
 private:
   static bool ourSquaring;


### PR DESCRIPTION
- downstream (macOS) has a subclass with non-const member functions that need to be called