### PR TITLE
minor fixes

### DIFF
--- a/source/Uthernet2.cpp
+++ b/source/Uthernet2.cpp
@@ -77,12 +77,8 @@ typedef int socklen_t;
 
 #endif
 
-// fix SOCK_NONBLOCK for e.g. macOS
-#ifndef SOCK_NONBLOCK
-// DISCALIMER
-// totally untested, use at your own risk
+#ifdef __APPLE__
 #include <fcntl.h>
-#define SOCK_NONBLOCK O_NONBLOCK
 #endif
 
 // Dest MAC + Source MAC + Ether Type
@@ -930,6 +926,8 @@ void Uthernet2::openSystemSocket(const size_t i, const int type, const int proto
 #ifdef _MSC_VER
         u_long on = 1;
         ioctlsocket(fd, FIONBIO, &on);
+#elif __APPLE__
+        fcntl(fd, O_NONBLOCK);
 #endif
         s.setFD(fd, status);
     }

--- a/source/Uthernet2.cpp
+++ b/source/Uthernet2.cpp
@@ -912,7 +912,7 @@ void Uthernet2::resetRXTXBuffers(const size_t i)
 void Uthernet2::openSystemSocket(const size_t i, const int type, const int protocol, const int status)
 {
     Socket &s = mySockets[i];
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(__APPLE__)
     const Socket::socket_t fd = socket(AF_INET, type, protocol);
 #else
     const Socket::socket_t fd = socket(AF_INET, type | SOCK_NONBLOCK, protocol);

--- a/source/frontends/common2/programoptions.h
+++ b/source/frontends/common2/programoptions.h
@@ -71,7 +71,7 @@ namespace common2
     std::vector<std::string> natPortFwds;
   };
 
-  enum class OptionsType { applen, sa2 };
+  enum class OptionsType { applen, sa2, mariani };
   bool getEmulatorOptions(int argc, const char * argv [], OptionsType type, const std::string & edition, EmulatorOptions & options);
 
   void applyOptions(const EmulatorOptions & options);


### PR DESCRIPTION
- avoid `SOCK_NONBLOCK` when building for Apple platforms
- add `mariani` to getEmulatorOptions() so it doesn't have to falsely claim to be `sa2`.