### PR TITLE
FreeBSD: Fix to build APPLEN

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -257,10 +257,22 @@ target_include_directories(appleii PRIVATE
   )
 
 # this one appears in header files
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "FreeBSD")
+# FreeBSD could already have "zip.h" (from libzip) in /usr/local/include
+# which takes precedence than the one in /usr/local/include/minizip.
+# "zip.h" from libzip is not what we want here.
+# The following changes to use include path /usr/local/include for minizip
+# so that the code can include "minizip/zip.h" explicitly.
+target_include_directories(appleii PUBLIC
+  ${CMAKE_CURRENT_BINARY_DIR}  # for config.h
+  ${MINIZIP_INCLUDE_DIRS}/..
+  )
+else()
 target_include_directories(appleii PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}  # for config.h
   ${MINIZIP_INCLUDE_DIRS}
   )
+endif()
 
 target_link_libraries(appleii PRIVATE
   ${YAML_LIBRARIES}

--- a/source/Tfe/DNS.cpp
+++ b/source/Tfe/DNS.cpp
@@ -26,6 +26,9 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#ifdef __FreeBSD__
+#include <sys/socket.h> // AF_INET.
+#endif
 #endif
 
 uint32_t getHostByName(const std::string & name)

--- a/source/Uthernet2.cpp
+++ b/source/Uthernet2.cpp
@@ -75,6 +75,9 @@ typedef int socklen_t;
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
+#ifdef __FreeBSD__
+#include <netinet/in.h> // sockaddr_in.
+#endif
 
 #endif
 

--- a/source/linux/network/portfwds.cpp
+++ b/source/linux/network/portfwds.cpp
@@ -8,6 +8,9 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
+#ifdef __FreeBSD__
+#include <netinet/in.h> // sockaddr_in.
+#endif
 
 namespace
 {


### PR DESCRIPTION
Some tweaks to get APPLEN target to build on FreeBSD.
Not yet verify if the build actually works on FreeBSD.