### PR TITLE
Fix "implicit instantiation of undefined template"

### DIFF
--- a/source/frontends/sdl/imgui/sdlmemory.cpp
+++ b/source/frontends/sdl/imgui/sdlmemory.cpp
@@ -7,6 +7,7 @@
 #include "Debugger/DebugDefs.h"
 #include "StrFormat.h"
 
+#include <sstream>
 #include <iomanip>
 
 namespace sa2


### PR DESCRIPTION
Encountered errors building sa2 on macOS:

```
          std::ostringstream hex;
          std::ostringstream text;
```
