### PR TITLE
minizip: include from the zlib root.

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -6,6 +6,12 @@ pkg_search_module(YAML REQUIRED yaml-0.1)
 pkg_search_module(MINIZIP REQUIRED minizip)
 pkg_search_module(SLIRP slirp)
 
+# see https://github.com/madler/zlib/commit/7e6f0784cc0c33e8d5fcb368248168c6656f73c8
+if (MINIZIP_INCLUDE_DIRS MATCHES "minizip$")
+  # old style, include from the zlib root
+  string(APPEND MINIZIP_INCLUDE_DIRS "/..")
+endif()
+
 # if slirp is not found, we will try pcap
 # if it is not found either, a dummy pcap will be compiled
 # but network will be badly affected

--- a/source/DiskImageHelper.cpp
+++ b/source/DiskImageHelper.cpp
@@ -34,7 +34,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #include "Common.h"
 
 #include "zlib.h"
-#include "unzip.h"
+#include "minizip/unzip.h"
 
 #include "CPU.h"
 #include "DiskImage.h"

--- a/source/DiskImageHelper.h
+++ b/source/DiskImageHelper.h
@@ -2,7 +2,7 @@
 
 #include "DiskDefs.h"
 #include "DiskImage.h"
-#include "zip.h"
+#include "minizip/zip.h"
 
 #define GZ_SUFFIX ".gz"
 #define GZ_SUFFIX_LEN (sizeof(GZ_SUFFIX)-1)


### PR DESCRIPTION
This is the strategic layout of zlib & minizip.

See https://github.com/audetto/AppleWin/pull/170