### PR TITLE
Updated cpack debian control file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Apple ][ emulator for Linux")
 set(CPACK_PACKAGE_CONTACT "audetto <mariofutire@gmail.com>")
 
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libyaml-0-2,libminizip1,libqt5gui5,libqt5widgets5,libqt5multimedia5,libqt5gamepad5,libncursesw6,libevdev2,libsdl2-image-2.0-0,libsdl2-2.0-0,libgles2,libpcap0.8,libslirp0,libboost-program-options1.74.0")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libyaml-0-2,libminizip1,libqt5gui5,libqt5widgets5,libqt5multimedia5,libqt5gamepad5,libncursesw6,libevdev2,libsdl2-image-2.0-0,libsdl2-2.0-0,libgles2,libpcap0.8,libslirp0,libboost-program-options1.74.0|libboost-program-options1.81.0|libboost-program-options1.83.0")
 
 set(CPACK_RPM_PACKAGE_LICENSE "GPLv2")
 set(CPACK_RPM_PACKAGE_GROUP "Applications/Emulators")


### PR DESCRIPTION
## Implements issue #180

For future versions of Debian, especially Trixie, Debian package creation needs to be updated to change the version of the package dependencies, or the package installation on the system will fail, without configuring the package.

This package: `libboost-program-options1.74.0`, need to be replaced. AppleWin do work with version 1.81.0 and 1.83.0. I think the best way to do this is to add alternatives by using pipe `|`:

- `libboost-program-options1.74.0 | libboost-program-options1.81.0 | libboost-program-options1.83.0`

In this PR i just added versions 1.81 and 1.83 as alternatives if 1.74 is not found. I have tested in Debian Trixie and it worked.

Here's a list of versions for [libboost-program-options](https://packages.debian.org/search?suite=default&section=all&arch=any&searchon=names&keywords=libboost-program-options1) in debian.packages.org.
