### PR TITLE
libwindows: remove many non needed declarations.

### DIFF
--- a/source/linux/libwindows/wincompat.h
+++ b/source/linux/libwindows/wincompat.h
@@ -27,10 +27,8 @@ extern "C" {
 #ifndef BASETYPES
 #define BASETYPES
 typedef uint32_t ULONG;  // 32 bit long in VS
-typedef ULONG *PULONG;
 typedef uint16_t USHORT;
 typedef unsigned char UCHAR;
-typedef char *PSZ;
 #endif  /* !BASETYPES */
 
 typedef int16_t INT16;
@@ -52,9 +50,6 @@ typedef uintptr_t UINT_PTR;
 typedef __int64 LONGLONG;
 
 typedef uint32_t UINT32;
-typedef uint8_t UINT8;
-typedef int32_t INT32;
-
 
 #define MAX_PATH          260
 
@@ -74,34 +69,8 @@ typedef int32_t INT32;
 #define TRUE                1
 #endif
 
-#ifndef IN
-#define IN
-#endif
+#define FAR
 
-#ifndef OUT
-#define OUT
-#endif
-
-#ifndef OPTIONAL
-#define OPTIONAL
-#endif
-
-#undef far
-#undef near
-#undef pascal
-
-#define far
-#define near
-#if (!defined(_MAC)) && ((_MSC_VER >= 800) || defined(_STDCALL_SUPPORTED))
-#define pascal __stdcall
-#else
-#define pascal
-#endif
-
-#undef FAR
-#undef NEAR
-#define FAR                 far
-#define NEAR                near
 #ifndef CONST
 #define CONST               const
 #endif
@@ -110,17 +79,12 @@ typedef uint32_t            DWORD;
 typedef int32_t             BOOL;
 typedef unsigned char       BYTE;
 typedef uint16_t            WORD;
-typedef float               FLOAT;
-typedef BOOL near           *PBOOL;
-typedef BOOL far            *LPBOOL;
-typedef BYTE near           *PBYTE;
-typedef BYTE far            *LPBYTE;
-typedef WORD near           *PWORD;
-typedef WORD far            *LPWORD;
-typedef DWORD near          *PDWORD;
-typedef DWORD far           *LPDWORD;
-typedef void far            *LPVOID;
-typedef CONST void far      *LPCVOID;
+typedef BOOL                *LPBOOL;
+typedef BYTE                *LPBYTE;
+typedef WORD                *LPWORD;
+typedef DWORD               *LPDWORD;
+typedef void                *LPVOID;
+typedef CONST void          *LPCVOID;
 
 typedef int32_t             INT;
 typedef uint32_t            UINT;
@@ -141,7 +105,6 @@ typedef DWORD   *LPCOLORREF;
 typedef char CHAR;
 typedef short SHORT;
 typedef int32_t /*long*/ LONG;
-typedef SHORT *PSHORT;
 typedef LONG *PLONG;
 typedef wchar_t WCHAR;
 
@@ -151,25 +114,20 @@ typedef uintptr_t       ULONG_PTR;
 typedef LONG_PTR        LRESULT;
 typedef ULONG_PTR       DWORD_PTR;
 
-typedef DWORD           LCID,       *PLCID;
+typedef DWORD           LCID;
 
-typedef unsigned __int64 UINT64, *PUINT64;
+typedef unsigned __int64 UINT64;
 
 //
 // ANSI (Multi-byte Character) types
 //
 typedef CHAR *PCHAR;
-typedef CHAR *LPCH, *PCH;
 
-typedef CONST CHAR *LPCCH, *PCCH;
-typedef CHAR *NPSTR;
-typedef CHAR *LPSTR, *PSTR;
-typedef CONST CHAR *LPCSTR, *PCSTR;
+typedef CHAR *LPSTR;
+typedef CONST CHAR *LPCSTR;
 
-typedef LPSTR LPTCH, PTCH;
 typedef LPSTR PTSTR, LPTSTR;
 typedef LPCSTR LPCTSTR;
-typedef LPSTR LP;
 
 typedef WCHAR *LPWSTR;
 typedef CONST WCHAR *LPCWSTR;
@@ -180,8 +138,7 @@ typedef CONST WCHAR *LPCWSTR;
 // othwerise QTCreator does not show the values (i.e. string) while debugging
 // it treats it as an array of bytes
 #define TCHAR char
-typedef TCHAR _TCHAR, *PTCHAR;
-typedef unsigned char TBYTE , *PTBYTE ;
+typedef TCHAR _TCHAR;
 #define _TCHAR_DEFINED
 #endif /* !_TCHAR_DEFINED */
 

--- a/source/linux/libwindows/wincompat.h
+++ b/source/linux/libwindows/wincompat.h
@@ -43,11 +43,12 @@ typedef uint16_t UINT16;
 // we stick to VS's definition
 // this is important when selecting the correct printf format specifier
 #define __int64 long long int
+typedef __int64 LONGLONG;
+typedef unsigned __int64 UINT64;
 
 typedef intptr_t INT_PTR;
 typedef uintptr_t UINT_PTR;
 
-typedef __int64 LONGLONG;
 
 typedef uint32_t UINT32;
 
@@ -75,10 +76,10 @@ typedef uint32_t UINT32;
 #define CONST               const
 #endif
 
-typedef uint32_t            DWORD;
-typedef int32_t             BOOL;
+typedef unsigned int        DWORD;
+typedef int                 BOOL;
 typedef unsigned char       BYTE;
-typedef uint16_t            WORD;
+typedef unsigned short      WORD;
 typedef BOOL                *LPBOOL;
 typedef BYTE                *LPBYTE;
 typedef WORD                *LPWORD;
@@ -86,8 +87,8 @@ typedef DWORD               *LPDWORD;
 typedef void                *LPVOID;
 typedef CONST void          *LPCVOID;
 
-typedef int32_t             INT;
-typedef uint32_t            UINT;
+typedef int                 INT;
+typedef unsigned int        UINT;
 
 #define MAKEWORD(a, b)      ((WORD)(((BYTE)(a)) | ((WORD)((BYTE)(b))) << 8))
 #define MAKELONG(a, b)      ((LONG)(((WORD)(a)) | ((DWORD)((WORD)(b))) << 16))
@@ -104,7 +105,7 @@ typedef DWORD   *LPCOLORREF;
 #define VOID void
 typedef char CHAR;
 typedef short SHORT;
-typedef int32_t /*long*/ LONG;
+typedef int /*long*/ LONG;
 typedef LONG *PLONG;
 typedef wchar_t WCHAR;
 
@@ -115,8 +116,6 @@ typedef LONG_PTR        LRESULT;
 typedef ULONG_PTR       DWORD_PTR;
 
 typedef DWORD           LCID;
-
-typedef unsigned __int64 UINT64;
 
 //
 // ANSI (Multi-byte Character) types

--- a/source/linux/libwindows/windows.h
+++ b/source/linux/libwindows/windows.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef _WIN32
+#error libwindows must not be used on Windows builds.
+#endif
+
 #include "wincompat.h"
 #include "guiddef.h"
 #include "winhandles.h"


### PR DESCRIPTION
#error if it is used in a Win32 configuration.