### PR TITLE
qapple: fix audio in Qt6.

### DIFF
--- a/source/frontends/qt/audioinfo.cpp
+++ b/source/frontends/qt/audioinfo.cpp
@@ -35,14 +35,18 @@ void AudioInfo::updateInfo(const qint64 speed, const qint64 target)
     myCounter = 0;
     const std::vector<QDirectSound::SoundInfo> &info = QDirectSound::getAudioInfo();
 
-    QString s("Voice   Channels  Buffer  Underruns\n");
+    QString s;
+    s.reserve(512); // empirically, enough for 2 MBs
+
+    s += "Voice   Channels  State  Buffer  Underruns\n";
     for (const auto &i : info)
     {
         if (i.running)
         {
-            s += QString("%1    %2    %3   %4\n")
+            s += QString("%1    %2      %3   %4    %5\n")
                      .arg(QString(i.voiceName.c_str()), -10)
                      .arg(i.channels, 2)
+                     .arg(i.state)
                      .arg(i.buffer, 4)
                      .arg(i.numberOfUnderruns, 8);
         }

--- a/source/frontends/qt/qdirectsound.h
+++ b/source/frontends/qt/qdirectsound.h
@@ -2,6 +2,7 @@
 #define DIRECTSOUND_H
 
 #include <QtGlobal>
+#include <QAudio>
 
 #include <vector>
 #include <string>
@@ -15,6 +16,7 @@ namespace QDirectSound
     {
         std::string voiceName;
         bool running = false;
+        QAudio::State state = QAudio::StoppedState;
         int channels = 0;
 
         // in milli seconds

--- a/source/linux/linuxsoundbuffer.cpp
+++ b/source/linux/linuxsoundbuffer.cpp
@@ -137,7 +137,7 @@ DWORD LinuxSoundBuffer::Read(
     return dwReadBytes;
 }
 
-DWORD LinuxSoundBuffer::GetBytesInBuffer()
+DWORD LinuxSoundBuffer::GetBytesInBuffer() const
 {
     const std::lock_guard<std::mutex> guard(myMutex);
     const DWORD available = (this->myWritePosition - this->myPlayPosition) % this->myBufferSize;

--- a/source/linux/linuxsoundbuffer.h
+++ b/source/linux/linuxsoundbuffer.h
@@ -19,7 +19,7 @@ private:
 
     // updated by the callback
     std::atomic_size_t myNumberOfUnderruns;
-    std::mutex myMutex;
+    mutable std::mutex myMutex;
 
 protected:
     LinuxSoundBuffer(DWORD dwBufferSize, DWORD nSampleRate, int nChannels, LPCSTR pszVoiceName);
@@ -31,10 +31,10 @@ public:
     const size_t myBitsPerSample;
     const std::string myVoiceName;
 
-    HRESULT SetCurrentPosition(DWORD dwNewPosition) override;
-    HRESULT GetCurrentPosition(LPDWORD lpdwCurrentPlayCursor, LPDWORD lpdwCurrentWriteCursor) override;
+    virtual HRESULT SetCurrentPosition(DWORD dwNewPosition) override;
+    virtual HRESULT GetCurrentPosition(LPDWORD lpdwCurrentPlayCursor, LPDWORD lpdwCurrentWriteCursor) override;
 
-    HRESULT Lock(
+    virtual HRESULT Lock(
         DWORD dwWriteCursor, DWORD dwWriteBytes, LPVOID *lplpvAudioPtr1, DWORD *lpdwAudioBytes1, LPVOID *lplpvAudioPtr2,
         DWORD *lpdwAudioBytes2, DWORD dwFlags) override;
     virtual HRESULT Unlock(LPVOID lpvAudioPtr1, DWORD dwAudioBytes1, LPVOID lpvAudioPtr2, DWORD dwAudioBytes2) override;
@@ -43,15 +43,15 @@ public:
     virtual HRESULT Play(DWORD dwReserved1, DWORD dwReserved2, DWORD dwFlags) override;
 
     virtual HRESULT SetVolume(LONG lVolume) override;
-    HRESULT GetVolume(LONG *lplVolume) override;
+    virtual HRESULT GetVolume(LONG *lplVolume) override;
 
-    HRESULT GetStatus(LPDWORD lpdwStatus) override;
-    HRESULT Restore() override;
+    virtual HRESULT GetStatus(LPDWORD lpdwStatus) override;
+    virtual HRESULT Restore() override;
 
     DWORD Read(
         DWORD dwReadBytes, LPVOID *lplpvAudioPtr1, DWORD *lpdwAudioBytes1, LPVOID *lplpvAudioPtr2,
         DWORD *lpdwAudioBytes2);
-    DWORD GetBytesInBuffer();
+    DWORD GetBytesInBuffer() const;
     size_t GetBufferUnderruns() const;
     void ResetUnderruns();
     double GetLogarithmicVolume() const; // in [0, 1]


### PR DESCRIPTION
One must notify `QAudioSink`, via the signal `readyRead()`, when more data is available.

Fixes https://github.com/audetto/AppleWin/issues/234