### PR TITLE
Fix compiler errors

### DIFF
--- a/source/linux/registryclass.h
+++ b/source/linux/registryclass.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <map>
 #include <memory>
+#include <cstdint>
 
 class Registry
 {


### PR DESCRIPTION
Avoid this issue 

```
/tmp/AppleWin/source/linux/registryclass.h:15:13: error: 'uint32_t' does not name a type
   15 |     virtual uint32_t getDWord(const std::string &section, const std::string &key) const = 0;
      |             ^~~~~~~~
/tmp/AppleWin/source/linux/registryclass.h:6:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
    5 | #include <memory>
  +++ |+#include <cstdint>
    6 | 
/tmp/AppleWin/source/linux/registryclass.h:19:85: error: 'uint32_t' does not name a type
   19 |     virtual void putDWord(const std::string &section, const std::string &key, const uint32_t value) = 0;
      |                                                                                     ^~~~~~~~
/tmp/AppleWin/source/linux/registryclass.h:19:85: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
[ 91%] Building CXX object source/frontends/common2/CMakeFiles/common2.dir/speed.cpp.o
/tmp/AppleWin/source/frontends/common2/ptreeregistry.h:24:18: error: 'uint32_t common2::PTreeRegistry::getDWord(const std::string&, const std::string&) const' marked 'override', but does not override
   24 |         uint32_t getDWord(const std::string &section, const std::string &key) const override;
      |                  ^~~~~~~~
/tmp/AppleWin/source/frontends/common2/ptreeregistry.h:28:14: error: 'void common2::PTreeRegistry::putDWord(const std::string&, const std::string&, uint32_t)' marked 'override', but does not override
   28 |         void putDWord(const std::string &section, const std::string &key, const uint32_t value) override;
      |              ^~~~~~~~
make[2]: *** [source/frontends/common2/CMakeFiles/common2.dir/build.make:163: source/frontends/common2/CMakeFiles/common2.dir/ptreeregistry.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:351: source/frontends/common2/CMakeFiles/common2.dir/all] Error 2
make: *** [Makefile:111: all] Error 2

```

using `gcc version 15.1.1 20250425 (GCC)`

