### PR TITLE
SaveState: honour the snapshot filename always.

### DIFF
--- a/source/frontends/common2/utils.cpp
+++ b/source/frontends/common2/utils.cpp
@@ -43,12 +43,8 @@ namespace common2
 
     void setSnapshotFilename(const std::filesystem::path &filename)
     {
-        if (std::filesystem::exists(filename))
-        {
-            std::filesystem::current_path(filename.parent_path());
-            Snapshot_SetFilename(filename.string());
-            RegSaveString(REG_CONFIG, REGVALUE_SAVESTATE_FILENAME, 1, Snapshot_GetPathname());
-        }
+        Snapshot_SetFilename(filename.string());
+        RegSaveString(REG_CONFIG, REGVALUE_SAVESTATE_FILENAME, 1, Snapshot_GetPathname());
     }
 
     void loadGeometryFromRegistry(const std::string &section, Geometry &geometry)


### PR DESCRIPTION
Even if it is missing: it will be created (or an error if tries to open it).

https://github.com/audetto/AppleWin/issues/278