### PR TITLE
Add ability to compile in msys2 with Ninja or MinGW Makefiles - DRAFT CHANGES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,14 +69,15 @@ if (BUILD_LIBRETRO)
   add_subdirectory(source/frontends/libretro)
 endif()
 
-if (NOT WIN32)
-  # not supported yet
+if (NOT WIN32 OR DEFINED ENV{MSYSTEM})
+  # SA2 and QAPPLE supported on Linux and MSYS2
 
   if (BUILD_QAPPLE)
     add_subdirectory(source/frontends/qt)
   endif()
 
   if (BUILD_SA2)
+    MESSAGE("Adding SA2 subdirectory: source/frontends/sdl")
     add_subdirectory(source/frontends/sdl)
   endif()
 

--- a/minizip/CMakeLists.txt
+++ b/minizip/CMakeLists.txt
@@ -9,6 +9,12 @@ add_library(minizip STATIC
   ${SOURCE_FILES}
   )
 
+# Link minizip with zlib since it depends on it
+find_package(PkgConfig REQUIRED)
+pkg_search_module(ZLIB REQUIRED zlib)
+target_link_libraries(minizip PUBLIC ${ZLIB_LIBRARIES})
+target_include_directories(minizip PRIVATE ${ZLIB_INCLUDE_DIRS})
+
 # this is needed since we include unzip.h and zip.h as <minizip/unzip.h> and <minizip/zip.h>
 # see https://github.com/madler/zlib/commit/7e6f0784cc0c33e8d5fcb368248168c6656f73c8
 target_include_directories(minizip INTERFACE

--- a/source/frontends/sdl/CMakeLists.txt
+++ b/source/frontends/sdl/CMakeLists.txt
@@ -18,6 +18,14 @@ else()
   option(SA2_OPENGL "Prefer OpenGL over OpenGL ES" OFF)
 endif()
 
+# Force OpenGL on Windows to avoid missing glesv2 in MXE
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+  message(STATUS "Forcing SA2_OPENGL ON on Windows to avoid GLES2 dependency")
+  set(SA2_OPENGL ON CACHE BOOL "" FORCE)
+
+  message(STATUS "SDL2_LIBRARIES = ${SDL2_LIBRARIES}")
+endif()
+
 if (SA2_OPENGL)
   find_package(OpenGL REQUIRED)
 else()
@@ -51,8 +59,11 @@ set(HEADER_FILES
 target_include_directories(sa2 PRIVATE
   ${SDL2_INCLUDE_DIRS}
   ${SDL2_IMAGE_INCLUDE_DIRS}
-  ${GLES2_INCLUDE_DIRS}
   )
+
+if (NOT SA2_OPENGL)
+  target_include_directories(sa2 PRIVATE ${GLES2_INCLUDE_DIRS})
+endif()
 
 target_link_libraries(sa2 PRIVATE
   appleii
@@ -64,9 +75,13 @@ target_link_libraries(sa2 PRIVATE
 
   ${SDL2_LIBRARIES}
   ${SDL2_IMAGE_LIBRARIES}
-  ${GLES2_LIBRARIES}
-  OpenGL::GL
   )
+
+if (NOT SA2_OPENGL)
+  target_link_libraries(sa2 PRIVATE ${GLES2_LIBRARIES})
+endif()
+
+target_link_libraries(sa2 PRIVATE OpenGL::GL)
 
 if (NOT WIN32)
   target_link_libraries(sa2 PUBLIC
@@ -77,8 +92,15 @@ endif()
 target_link_directories(sa2 PRIVATE
   ${SDL2_LIBRARY_DIRS}
   ${SDL2_IMAGE_LIBRARY_DIRS}
-  ${GLES2_LIBRARY_DIRS}
   )
+
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+  target_link_libraries(sa2 PRIVATE ws2_32)
+endif()
+
+if (NOT SA2_OPENGL)
+  target_link_directories(sa2 PRIVATE ${GLES2_LIBRARY_DIRS})
+endif()
 
 target_sources(sa2 PRIVATE
   ${SOURCE_FILES}

--- a/source/frontends/sdl/imgui/sdlimguiframe.cpp
+++ b/source/frontends/sdl/imgui/sdlimguiframe.cpp
@@ -107,7 +107,7 @@ namespace sa2
         myDebuggerFont = io.Fonts->AddFontFromMemoryTTF(
             const_cast<unsigned char *>(debug6502TTF.first), debug6502TTF.second, 13, &fontConfig);
 
-        myIniFileLocation = common2::getConfigFile("imgui.ini");
+        myIniFileLocation = common2::getConfigFile("imgui.ini").string();
         if (myIniFileLocation.empty())
         {
             io.IniFilename = nullptr;

--- a/source/frontends/sdl/main.cpp
+++ b/source/frontends/sdl/main.cpp
@@ -1,3 +1,4 @@
+#define SDL_MAIN_HANDLED
 #include <SDL.h>
 
 #include <iostream>
@@ -165,8 +166,11 @@ void run_sdl(int argc, char *const argv[])
     }
 #endif
 }
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-int main(int argc, char *const argv[])
+int SDL_main(int argc, char *argv[])
 {
     // First we need to start up SDL, and make sure it went ok
     const Uint32 flags = SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER | SDL_INIT_AUDIO | SDL_INIT_TIMER | SDL_INIT_EVENTS;
@@ -192,3 +196,19 @@ int main(int argc, char *const argv[])
 
     return exit;
 }
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#ifdef _WIN32
+// Windows-specific wrapper main to satisfy SDL2 linker expecting main
+int main(int argc, char *argv[])
+{
+    return SDL_main(argc, argv);
+}
+#else
+// On non-Windows just use SDL_main as main
+int main(int argc, char *argv[]) __attribute__((alias("SDL_main")));
+#endif

--- a/source/frontends/sdl/processfile.cpp
+++ b/source/frontends/sdl/processfile.cpp
@@ -11,6 +11,7 @@
 #include "Harddisk.h"
 
 #include <algorithm>
+#include <cstring>
 #include <sstream>
 
 namespace


### PR DESCRIPTION
After working on the cross build as reported in #290 I thought I'd try applying the changes and building in msys2 MinGW64 on windows directly.

This is working except for 1 issue I can't understand.
When choosing "Color (RGB Card/Monitor)" as the Video, the screen goes wrong. If you step debug, you can see the "Apple II" at the top of the screen, but it's constantly being paited over. Difficult to explain.

Otherwise all SDL2 / ImgUI windows are working fine, the debugger etc works as expected from the limited testing I did.

# Compiling

I used msys2 MINGW64 environment, with all the appropriate boost, SDL2, SDL2_image, etc libraries installed locally, so no use of mxe or docker images.
I installed both "cninja" and standard gnu compilation packages.

Compiling with Ninja:
```shell
mkdir build && cd build
cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SA2=on
cmake --build .
```

Compiling with MinGW Makefiles:
```shell
mkdir build && cd build
cmake -G "MinGW Makefiles" .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SA2=on
cmake --build .
```

Interestingly I had to make some changes I didn't need to in #290 which you can see in the patch.

I'd like to get a second pair of eyes on this change and see if it's just my machine that has the problem.
I didn't have the RGB issues when using linux->windows compilation on our fork.
I did note that msys2 uses a different SDL2 compared to linux->windows:

linux compiled version is using SDL version 2.26.2
msys compiled version is using SDL version 2.32.8

One other difference was the EXE size, under msys2 it was 6Mb, linux is statically compiling and creates a 29Mb file.
I'm not sure how to get a statically linked build working on msys2.

However, I was hoping this was a decent start to getting SDL2 working under windows without a linux cross compilation environment.