### PR TITLE
Update libretro info file as per current status.

### DIFF
--- a/source/frontends/libretro/info/applewin_libretro.info
+++ b/source/frontends/libretro/info/applewin_libretro.info
@@ -1,11 +1,81 @@
 # Software Information - Information about the core software itself
+# Name displayed when the user is selecting the core:
 display_name = "Apple - apple ][ (AppleWin)"
-license = "GPLv2"
+
+# Categories that the core belongs to (optional):
 categories = "Emulator"
+
+# Name of the authors who wrote the core:
+# authors = "???"
+
+# Name of the core:
+corename = "applewin"
+
+# List of extensions the core supports:
+supported_extensions = "bin|do|dsk|nib|po|gz|woz|zip|2mg|2img|iie|apl|hdv|yaml|m3u"
+
+# License of the cores source code:
+license = "GPLv2"
+
+# Privacy-specific permissions needed for using the core:
+# permissions = ""
+
+# Version of the core:
+# display_version = "1.30.21.0"
+
+# Hardware Information - Information about the hardware the core supports (when applicable)
+# Name of the manufacturer who produced the emulated system:
 manufacturer = "Apple"
 
+# Name of the system that the core targets (optional):
+# systemname = "II"
+
+# ID of the primary platform the core uses. Use other core info files as guidance if possible.
+# If blank or not used, a standard core platform will be used (optional):
+# systemid = "apple_ii"
+
+# The number of mandatory/optional firmware files the core needs:
+# firmware_count = 0
+
+# Additional notes:
+# notes = "(!) hash|(!) game rom|(^) continue|[1] notes|[^] continue|[*] list"
+
 # Libretro Features - The libretro API features the core supports. Useful for sorting cores
+# Does the core support savestates
 savestate = "true"
+# If true, how complete is the savestate support? basic, serialized (rewind), deterministic (netplay/runahead)
 savestate_features = "serialized"
+# Does the core support the libretro cheat interface?
+# cheats = "false"
+# Does the core support libretro input descriptors
+# input_descriptors = "true"
+# Does the core support memory descriptors commonly used for achievements
+# memory_descriptors = "false"
+# Does the core use the libretro save interface or does it do its own thing (like with shared memory cards)?
+# libretro_saves = "true"
+# Does the core support the core options interface?
+core_options = "true"
+# What version of core options is supported? (later versions allow for localization and descriptions)
+core_options_version = "2.0"
+# Does the core support the subsystem interface? Commonly used for chained/special loading, such as Super Game Boy
+# load_subsystem = "false"
+# Whether or not the core requires an external file to work:
 supports_no_game = "true"
-supported_extensions = "bin|do|dsk|nib|po|gz|woz|zip|2mg|2img|iie|apl|hdv|yaml|m3u"
+# Does the core have a single purpose? Does it represent one game or application, requiring predetermined support files or no external data? Used to indicate to a frontend that the core may be presented/handled independently from 'regular' cores that run a variety of content.
+# single_purpose = "false"
+# Name of the database that the core supports (optional):
+# Note: Apple II database is not present in libretro systems yet
+# database = "Apple - II"
+# Does the core support/require support for libretro-gl or other hardware-acceleration in the frontend?
+hw_render = "false"
+# Which hardware-rendering APIs does the core support? Delimited by pipe characters.
+# required_hw_api = "Vulkan >= 1.0 | Direct3D >= 10.0 | OpenGL Core >= 3.3 | OpenGL ES >= 3.0"
+# Does the core require ongoing access to the file after loading? Mostly used for softpatching and streaming of data
+# needs_fullpath = "false"
+# Does the core support the libretro disk control interface for swapping disks on the fly?
+disk_control = "true"
+# Is the core currently suitable for general use? That is, will regular users find it useful or is it for development/testing only (subject to change over time)?
+is_experimental = "false"
+
+# Descriptive text, useful for tooltips, etc.
+description = "Apple II emulator. This is a linux port of AppleWin, that shares 100% of the code of the core emulator and video generation. This port is also available for Windows and other platforms."

--- a/source/frontends/libretro/info/applewin_libretro.info
+++ b/source/frontends/libretro/info/applewin_libretro.info
@@ -17,63 +17,47 @@ supported_extensions = "bin|do|dsk|nib|po|gz|woz|zip|2mg|2img|iie|apl|hdv|yaml|m
 # License of the cores source code:
 license = "GPLv2"
 
-# Privacy-specific permissions needed for using the core:
-# permissions = ""
-
 # Version of the core:
-# display_version = "1.30.21.0"
+display_version = "1.30.21.0"
 
 # Hardware Information - Information about the hardware the core supports (when applicable)
 # Name of the manufacturer who produced the emulated system:
 manufacturer = "Apple"
 
 # Name of the system that the core targets (optional):
-# systemname = "II"
+systemname = "II"
 
 # ID of the primary platform the core uses. Use other core info files as guidance if possible.
 # If blank or not used, a standard core platform will be used (optional):
-# systemid = "apple_ii"
-
-# The number of mandatory/optional firmware files the core needs:
-# firmware_count = 0
-
-# Additional notes:
-# notes = "(!) hash|(!) game rom|(^) continue|[1] notes|[^] continue|[*] list"
+systemid = "apple_ii"
 
 # Libretro Features - The libretro API features the core supports. Useful for sorting cores
 # Does the core support savestates
 savestate = "true"
 # If true, how complete is the savestate support? basic, serialized (rewind), deterministic (netplay/runahead)
 savestate_features = "serialized"
-# Does the core support the libretro cheat interface?
-# cheats = "false"
+
 # Does the core support libretro input descriptors
-# input_descriptors = "true"
-# Does the core support memory descriptors commonly used for achievements
-# memory_descriptors = "false"
-# Does the core use the libretro save interface or does it do its own thing (like with shared memory cards)?
-# libretro_saves = "true"
+input_descriptors = "true"
+
 # Does the core support the core options interface?
 core_options = "true"
 # What version of core options is supported? (later versions allow for localization and descriptions)
 core_options_version = "2.0"
-# Does the core support the subsystem interface? Commonly used for chained/special loading, such as Super Game Boy
-# load_subsystem = "false"
+
 # Whether or not the core requires an external file to work:
 supports_no_game = "true"
-# Does the core have a single purpose? Does it represent one game or application, requiring predetermined support files or no external data? Used to indicate to a frontend that the core may be presented/handled independently from 'regular' cores that run a variety of content.
-# single_purpose = "false"
+
 # Name of the database that the core supports (optional):
 # Note: Apple II database is not present in libretro systems yet
 # database = "Apple - II"
+
 # Does the core support/require support for libretro-gl or other hardware-acceleration in the frontend?
 hw_render = "false"
-# Which hardware-rendering APIs does the core support? Delimited by pipe characters.
-# required_hw_api = "Vulkan >= 1.0 | Direct3D >= 10.0 | OpenGL Core >= 3.3 | OpenGL ES >= 3.0"
-# Does the core require ongoing access to the file after loading? Mostly used for softpatching and streaming of data
-# needs_fullpath = "false"
+
 # Does the core support the libretro disk control interface for swapping disks on the fly?
 disk_control = "true"
+
 # Is the core currently suitable for general use? That is, will regular users find it useful or is it for development/testing only (subject to change over time)?
 is_experimental = "false"
 


### PR DESCRIPTION
Let's pick up the conversation in #253 .

Values are filled based on the current code, maybe 2 questions:
- who to put as author? (Line 9) I could not find a preferred designation from the repo (neither this fork nor the original AppleWin)
- description (Line 81) could be refined, it will be confusing anyway (a Linux port of a Windows emulator, but it is available for other platforms including Windows) but maybe there is better wording