### PR TITLE
Enable 64 and 32-bit builds for Linux and Windows

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,17 +9,16 @@
   variables:
     CORENAME: applewin
     CORE_ARGS: '-DBUILD_LIBRETRO=ON -G Ninja'
-    EXTRA_PATH: source/frontends/libretro
 
 # Inclusion templates, required for the build to work
 include:
   ################################## DESKTOPS ################################
 
-  # Windows 64-bit
-#  - project: 'libretro-infrastructure/ci-templates'
-#    file: '/windows-cmake-mingw.yml'
+  # Windows
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/windows-cmake-mingw.yml'
 
-  # Linux 64-bit
+  # Linux
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-cmake.yml'
 
@@ -58,21 +57,52 @@ stages:
 #
 ################################### DESKTOPS #################################
 # Windows 64-bit
-#libretro-build-windows-x64:
-#  extends:
-#    - .libretro-windows-cmake-x86_64
-#    - .core-defs
+libretro-build-windows-x64:
+  extends:
+    - .libretro-windows-cmake-x86_64
+    - .core-defs
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-mxe-win-cross-cores:gcc10
+  before_script:
+    - export NUMPROC=$(($(nproc)/5))
+    - apt-get update -qy
+    - apt-get -qy install vim
+
+# Windows 32-bit
+libretro-build-windows-i686:
+  extends:
+    - .libretro-windows-cmake-x86
+    - .core-defs
+  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-mxe-win-cross-cores:gcc10
+  before_script:
+    - export NUMPROC=$(($(nproc)/5))
+    - apt-get update -qy
+    - apt-get -qy install vim
 
 # Linux 64-bit
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-cmake-x86_64
     - .core-defs
-  image: $CI_SERVER_HOST:5050/libretro-infrastructure/libretro-build-amd64-ubuntu:xenial-gcc9
   before_script:
+    - export NUMPROC=$(($(nproc)/5))
     - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 16FAAD7AF99A65E2
     - sudo apt-get update -qy
     - sudo apt-get -qy install $(cat source/frontends/libretro/xenial/packages.txt)
+  variables:
+    EXTRA_PATH: source/frontends/libretro
+
+# Linux 32-bit
+libretro-build-linux-i686:
+  extends:
+    - .libretro-linux-cmake-x86
+    - .core-defs
+  before_script:
+    - export NUMPROC=$(($(nproc)/5))
+    - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 16FAAD7AF99A65E2
+    - sudo apt-get update -qy
+    - sudo apt-get -qy install $(cat source/frontends/libretro/xenial/packages.txt)
+  variables:
+    EXTRA_PATH: source/frontends/libretro
 
 # MacOS 64-bit
 #libretro-build-osx-x64:

--- a/source/StdAfx.h
+++ b/source/StdAfx.h
@@ -50,7 +50,11 @@
 #endif
 
 #ifdef __MINGW32__
+#ifdef __x86_64
 #define SIZE_T_FMT "I64u"
+#else
+#define SIZE_T_FMT "I32u"
+#endif
 #else
 #define SIZE_T_FMT "zu"
 #endif

--- a/source/Uthernet1.h
+++ b/source/Uthernet1.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "NetworkCard.h"
+#include "Tfe/tfearch.h"
 
 /* define this only if VICE should write each and every frame received
    and send into the VICE log
@@ -132,8 +133,8 @@ public:
 
 	virtual const std::shared_ptr<NetworkBackend> & GetNetworkBackend() const;
 
-	BYTE tfe_read(WORD ioaddress);
-	void tfe_store(WORD ioaddress, BYTE byte);
+	BYTE REGPARM1 tfe_read(WORD ioaddress);
+	void REGPARM2 tfe_store(WORD ioaddress, BYTE byte);
 
 	static const std::string& GetSnapshotCardName(void);
 

--- a/source/Z80VICE/z80.h
+++ b/source/Z80VICE/z80.h
@@ -27,6 +27,12 @@
 #ifndef _Z80_H
 #define _Z80_H
 
+#ifdef WATCOM_COMPILE
+#include "../mem.h"
+#else
+#include "../CommonVICE/mem.h"         // [AppleWin-TC]
+#endif
+
 struct z80_regs_s;
 
 extern struct z80_regs_s z80_regs;
@@ -40,11 +46,13 @@ extern void z80_reset(void);
 DWORD z80_mainloop(ULONG uTotalCycles, ULONG uExecutedCycles);
 //extern void z80_trigger_dma(void);
 
-BYTE z80_RDMEM(WORD Addr);
-void z80_WRMEM(WORD Addr, BYTE Value);
+BYTE REGPARM1 z80_RDMEM(WORD Addr);
+void REGPARM2 z80_WRMEM(WORD Addr, BYTE Value);
 
 const std::string& Z80_GetSnapshotCardName(void);
 void Z80_SaveSnapshot(class YamlSaveHelper& yamlSaveHelper, const UINT uSlot);
 bool Z80_LoadSnapshot(class YamlLoadHelper& yamlLoadHelper, UINT uSlot, UINT version);
 
 #endif
+
+


### PR DESCRIPTION
Gitlab CI file updated. A few other alignments were also needed:
- fixing REGPARM references (only used in case of 32-bit, wonder if they caused problems in other builds)
- yet another fix for the format specifier in StdAfx.h

Builds are passing:
https://git.libretro.com/warmenhoven/applewin/-/pipelines/7528