### PR TITLE
Visual Studio compilation fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # this is originally a Windows project, so it uses _DEBUG, not NDEBUG
 add_compile_definitions("$<$<CONFIG:DEBUG>:_DEBUG>")
-add_compile_options(-Werror=return-type -Wno-switch)
+if (MSVC)
+  add_compile_options(/W4)
+else()
+  add_compile_options(-Werror=return-type -Wno-switch)
+endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   add_compile_options(-Werror=format -Wno-error=format-overflow -Wno-error=format-truncation -Wno-psabi)
@@ -71,6 +75,7 @@ endif()
 
 if (BUILD_SA2)
   add_subdirectory(source/frontends/sdl)
+  set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT sa2)
 endif()
 
 if (NOT WIN32)

--- a/libyaml/CMakeLists.txt
+++ b/libyaml/CMakeLists.txt
@@ -24,3 +24,7 @@ target_include_directories(yaml PRIVATE
 target_compile_definitions(yaml PRIVATE
   HAVE_CONFIG_H
   )
+
+if (MSVC)
+  target_compile_definitions(yaml PUBLIC YAML_DECLARE_STATIC)
+endif()

--- a/minizip/CMakeLists.txt
+++ b/minizip/CMakeLists.txt
@@ -14,3 +14,7 @@ add_library(minizip STATIC
 target_include_directories(minizip INTERFACE
   ${CMAKE_CURRENT_SOURCE_DIR}/..
   )
+
+find_package(ZLIB REQUIRED)
+
+target_link_libraries(minizip PRIVATE ZLIB::ZLIB)

--- a/resource/CMakeResources.cmake
+++ b/resource/CMakeResources.cmake
@@ -43,7 +43,7 @@ function(add_resources out_var id)
     string(APPEND content_cpp_private
       "// ${in_f_bin}\n"
       "extern unsigned char ${symbol}[]\;\n"
-      "extern int ${symbol}_len\;\n"
+      "extern unsigned int ${symbol}_len\;\n"
       "\n")
     string(APPEND content_cpp_public
       "        {${resource_id}, {${symbol}, ${symbol}_len}},\n")

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -276,6 +276,7 @@ endif()
 target_link_libraries(appleii PUBLIC
   yaml
   minizip
+  apple2roms
   )
 
 target_link_directories(appleii PUBLIC
@@ -284,9 +285,19 @@ target_link_directories(appleii PUBLIC
   ${ZLIB_LIBRARY_DIRS}
   )
 
-target_compile_options(appleii PUBLIC
-  -Wno-multichar
+if (MSVC)
+  target_compile_options(appleii PUBLIC
+    /wd4566   # disable multi-character constant warning
   )
+  target_compile_definitions(appleii PRIVATE 
+    NOMINMAX            # to avoid conflicts with std::min/max
+    DISABLE_SPEECH_API  # undefine because the original AppleWin speech API is not supported here
+  )
+else()
+  target_compile_options(appleii PUBLIC
+    -Wno-multichar
+  )
+endif()
 
 # wildcards (*.SYM) are not supported on Windows msys2
 add_custom_command(

--- a/source/StdAfx.h
+++ b/source/StdAfx.h
@@ -45,8 +45,10 @@
 #define SM_CXPADDEDBORDER 92
 #endif
 
-#ifndef __MINGW32__ 
-#define USE_SPEECH_API
+#ifndef DISABLE_SPEECH_API
+#  ifndef __MINGW32__
+#    define USE_SPEECH_API
+#  endif
 #endif
 
 #ifdef __MINGW32__

--- a/source/frontends/common2/CMakeLists.txt
+++ b/source/frontends/common2/CMakeLists.txt
@@ -45,6 +45,20 @@ target_link_libraries(common2 PRIVATE
   apple2roms
   )
 
+# ---- getopt for Windows (MSVC/MinGW on Win32) ----
+if (WIN32)
+  # Build the local getopt implementation and expose its headers to this target
+  target_sources(common2 PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/getopt.c
+  )
+  target_include_directories(common2 PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+
+  # Prevent <Windows.h> from defining min/max macros, which break numeric_limits::min/max
+  target_compile_definitions(common2 PRIVATE NOMINMAX)
+endif()
+
 if (NOT WIN32)
   target_link_libraries(common2 PUBLIC
     windows

--- a/source/frontends/common2/argparser.cpp
+++ b/source/frontends/common2/argparser.cpp
@@ -6,7 +6,11 @@
 
 #include "Memory.h"
 
-#include <getopt.h>
+#ifdef _WIN32
+#  include "frontends/common2/getopt.h"
+#else
+#  include <getopt.h>
+#endif
 #include <regex>
 #include <iostream>
 #include <iomanip>

--- a/source/frontends/common2/getopt.c
+++ b/source/frontends/common2/getopt.c
@@ -1,0 +1,109 @@
+#include "getopt.h"
+#include <string.h>
+#include <stdio.h>
+
+// For Windows MSVC only
+
+char *optarg = NULL;
+int optind = 1, opterr = 1, optopt = '?';
+
+static int optpos = 1;
+
+static int
+_parse_short(int argc, char * const argv[], const char *optstring)
+{
+    char c = argv[optind][optpos];
+    const char *cp = strchr(optstring, c);
+
+    if (!cp) {
+        if (opterr)
+            fprintf(stderr, "unknown option -- %c\n", c);
+        if (argv[optind][++optpos] == '\0') {
+            optind++;
+            optpos = 1;
+        }
+        optopt = c;
+        return '?';
+    }
+    if (cp[1] == ':') {
+        if (argv[optind][optpos+1] != '\0') {
+            optarg = &argv[optind][optpos+1];
+            optind++;
+        } else if (++optind < argc) {
+            optarg = argv[optind++];
+        } else {
+            optopt = c;
+            return (optstring[0] == ':') ? ':' : '?';
+        }
+        optpos = 1;
+    } else {
+        if (argv[optind][++optpos] == '\0') {
+            optpos = 1;
+            optind++;
+        }
+        optarg = NULL;
+    }
+    return c;
+}
+
+int getopt(int argc, char * const argv[], const char *optstring)
+{
+    if (optind >= argc || argv[optind][0] != '-' || argv[optind][1] == '\0')
+        return -1;
+    if (strcmp(argv[optind], "--") == 0) {
+        optind++;
+        return -1;
+    }
+    return _parse_short(argc, argv, optstring);
+}
+
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex)
+{
+    if (optind >= argc) return -1;
+
+    if (argv[optind][0] == '-' && argv[optind][1] == '-') {
+        const char *name = argv[optind] + 2;
+        const char *eq = strchr(name, '=');
+        size_t len = eq ? (size_t)(eq - name) : strlen(name);
+
+        for (int i = 0; longopts[i].name; i++) {
+            if (strncmp(name, longopts[i].name, len) == 0
+                && len == strlen(longopts[i].name)) {
+                if (longindex) *longindex = i;
+                if (longopts[i].has_arg == no_argument) {
+                    optarg = NULL;
+                } else if (longopts[i].has_arg == required_argument) {
+                    if (eq)
+                        optarg = (char*)eq+1;
+                    else if (optind+1 < argc)
+                        optarg = argv[++optind];
+                    else
+                        return optopt = longopts[i].val, '?';
+                } else if (longopts[i].has_arg == optional_argument) {
+                    optarg = eq ? (char*)eq+1 : NULL;
+                }
+                optind++;
+                if (longopts[i].flag) {
+                    *(longopts[i].flag) = longopts[i].val;
+                    return 0;
+                } else {
+                    return longopts[i].val;
+                }
+            }
+        }
+        /* no match */
+        if (opterr)
+            fprintf(stderr, "unrecognized option '--%s'\n", name);
+        optind++;
+        return '?';
+    }
+    /* fallback to short option parsing */
+    return getopt(argc, argv, optstring);
+}
+
+int getopt_long_only(int argc, char * const argv[], const char *optstring,
+                     const struct option *longopts, int *longindex)
+{
+    return getopt_long(argc, argv, optstring, longopts, longindex);
+}

--- a/source/frontends/common2/getopt.h
+++ b/source/frontends/common2/getopt.h
@@ -1,0 +1,39 @@
+#ifndef GETOPT_H
+#define GETOPT_H
+
+// For Windows MSVC only
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* argument flags */
+#define no_argument        0
+#define required_argument  1
+#define optional_argument  2
+
+struct option {
+    const char *name;
+    int  has_arg;
+    int *flag;
+    int  val;
+};
+
+/* globals */
+extern char *optarg;
+extern int optind, opterr, optopt;
+
+/* functions */
+int getopt(int argc, char * const argv[], const char *optstring);
+
+int getopt_long(int argc, char * const argv[], const char *optstring,
+                const struct option *longopts, int *longindex);
+
+int getopt_long_only(int argc, char * const argv[], const char *optstring,
+                     const struct option *longopts, int *longindex);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GETOPT_H */

--- a/source/frontends/docs/msvc.md
+++ b/source/frontends/docs/msvc.md
@@ -1,0 +1,29 @@
+# Microsoft VisualStudio support
+
+## Why
+
+The original AppleWin project is built with Visual Studio. We now provide support for Visual Studio when building 'sa2', the SDL version of AppleWin.
+
+## Status
+
+`sa2` compiles under VisualStudio 2022.
+
+## Building
+
+Very **important** to install `vcpkg`. Refer to the Microsoft documentation.
+
+Install using `vcpkg` the following packages:
+```
+vcpkg install sdl2 sdl2-image sdl2-ttf
+vcpkg install zlib
+vcpkg install boost
+```
+Then configure:
+```
+cmake -B build -S . -DCMAKE_TOOLCHAIN_FILE=C:\PATH_TO_VCPKG\scripts\buildsystems\vcpkg.cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DVCPKG_TARGET_TRIPLET=x64-windows -DBUILD_SA2=ON
+```
+Then open the generated `build\applewin.sln` file in Visual Studio.
+
+## Running
+
+`sa2` should be the startup project that runs when you press F5.

--- a/source/frontends/sdl/CMakeLists.txt
+++ b/source/frontends/sdl/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(SDL2 REQUIRED)
 # we should use find_package, but Ubuntu does not provide it for SDL2_image
 pkg_search_module(SDL2_IMAGE REQUIRED SDL2_image)
 
+target_compile_features(common2 PUBLIC cxx_std_20)
 
 if ((${CMAKE_SYSTEM_NAME} MATCHES "Darwin") OR (${CMAKE_SYSTEM_NAME} MATCHES "Windows"))
   # only OpenGL supported on MacOS and Windows
@@ -26,7 +27,6 @@ else()
     IMGUI_IMPL_OPENGL_ES2
   )
 endif()
-
 
 set(SOURCE_FILES
   main.cpp
@@ -126,9 +126,24 @@ target_include_directories(sa2 PRIVATE
   ${IMGUI_CLUB_PATH}/imgui_memory_editor
   )
 
-target_compile_definitions(sa2 PRIVATE
-  IMGUI_USER_CONFIG="frontends/sdl/imgui/imconfig.h"
+if (MSVC)
+  target_compile_definitions(sa2 PRIVATE 
+    NOMINMAX            # to avoid conflicts with std::min/max
+    DISABLE_SPEECH_API  # undefine because the original AppleWin speech API is not supported here
+    IMGUI_USER_CONFIG="frontends/sdl/imgui/imconfig.h"
+  )      
+else()
+  target_compile_definitions(sa2 PRIVATE
+    IMGUI_USER_CONFIG="frontends/sdl/imgui/imconfig.h"
   )
+endif()
+
 
 install(TARGETS sa2
-  DESTINATION bin)
+  RUNTIME_DEPENDENCIES
+    PRE_EXCLUDE_REGEXES "api-ms-" "ext-ms-"    # skip Windows system DLLs
+    POST_EXCLUDE_REGEXES ".*system32/.*"       # skip more system DLLs
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION bin
+  ARCHIVE DESTINATION lib
+)

--- a/source/frontends/sdl/imgui/sdldebugger.cpp
+++ b/source/frontends/sdl/imgui/sdldebugger.cpp
@@ -52,7 +52,15 @@ namespace
             // the latter comes from https://fontstruct.com/fontstructions/show/1912741/debug6502
             switch (ch)
             {
-            case 0x00 ... 0x1F: // mouse text -> U+00C0
+            case 0x00: case 0x01: case 0x02: case 0x03:
+            case 0x04: case 0x05: case 0x06: case 0x07:
+            case 0x08: case 0x09: case 0x0A: case 0x0B:
+            case 0x0C: case 0x0D: case 0x0E: case 0x0F:
+            case 0x10: case 0x11: case 0x12: case 0x13:
+            case 0x14: case 0x15: case 0x16: case 0x17:
+            case 0x18: case 0x19: case 0x1A: case 0x1B:
+            case 0x1C: case 0x1D: case 0x1E: case 0x1F:
+            // mouse text -> U+00C0
                 *out = 0xC3;
                 ++out;
                 *out = 0x80 + (ch - 0x00);
@@ -62,7 +70,11 @@ namespace
                 ++out;
                 *out = 0xBF;
                 break;
-            case 0x80 ... 0x8F: // bookmarks, not currently used -> U+00F0
+            case 0x80: case 0x81: case 0x82: case 0x83:
+            case 0x84: case 0x85: case 0x86: case 0x87:
+            case 0x88: case 0x89: case 0x8A: case 0x8B:
+            case 0x8C: case 0x8D: case 0x8E: case 0x8F:
+                // bookmarks, not currently used -> U+00F0
                 *out = 0xC3;
                 ++out;
                 *out = 0xB0 + (ch - 0x80);
@@ -79,9 +91,9 @@ namespace
     void safeDebuggerTextColored(int iColor, const char *text)
     {
         const size_t length = strlen(text);
-        char utf8[2 * length + 1]; // worst case is 2-bytes utf8 encoding
-        adjustMouseText(text, length, utf8);
-        debuggerTextColored(iColor, utf8);
+		std::string utf8(2 * length + 1, '\0'); // worst case is 2-bytes utf8 encoding
+		adjustMouseText(text, length, utf8.data());
+		debuggerTextColored(iColor, utf8.c_str());
     }
 
     void displayDisassemblyLine(const DisasmLine_t &line, const int bDisasmFormatFlags)

--- a/source/frontends/sdl/processfile.cpp
+++ b/source/frontends/sdl/processfile.cpp
@@ -14,6 +14,10 @@
 #include <cstring>
 #include <sstream>
 
+#ifdef _WIN32
+#  define strcasecmp _stricmp
+#endif
+
 namespace
 {
 

--- a/source/frontends/sdl/sdlframe.cpp
+++ b/source/frontends/sdl/sdlframe.cpp
@@ -91,7 +91,12 @@ namespace
             ch = 0x09;
             break;
         }
-        case SDLK_a ... SDLK_z:
+        case SDLK_a: case SDLK_b: case SDLK_c: case SDLK_d: case SDLK_e:
+            case SDLK_f: case SDLK_g: case SDLK_h: case SDLK_i: case SDLK_j:
+            case SDLK_k: case SDLK_l: case SDLK_m: case SDLK_n: case SDLK_o:
+            case SDLK_p: case SDLK_q: case SDLK_r: case SDLK_s: case SDLK_t:
+            case SDLK_u: case SDLK_v: case SDLK_w: case SDLK_x: case SDLK_y:
+            case SDLK_z:
         {
             // same logic as AW
             // CAPS is forced when the emulator starts
@@ -576,9 +581,21 @@ namespace sa2
             const char key = text.text[0];
             switch (key)
             {
-            case 0x20 ... 0x40:
-            case 0x5b ... 0x60:
-            case 0x7b ... 0x7e:
+            // 0x20 ... 0x40
+            case 0x20: case 0x21: case 0x22: case 0x23: case 0x24:
+            case 0x25: case 0x26: case 0x27: case 0x28: case 0x29:
+            case 0x2A: case 0x2B: case 0x2C: case 0x2D: case 0x2E:
+            case 0x2F: case 0x30: case 0x31: case 0x32: case 0x33:
+            case 0x34: case 0x35: case 0x36: case 0x37: case 0x38:
+            case 0x39: case 0x3A: case 0x3B: case 0x3C: case 0x3D:
+            case 0x3E: case 0x3F: case 0x40:
+
+            // 0x5B ... 0x60
+            case 0x5B: case 0x5C: case 0x5D: case 0x5E:
+            case 0x5F: case 0x60:
+
+            // 0x7B ... 0x7E
+            case 0x7B: case 0x7C: case 0x7D: case 0x7E:
             {
                 // not the letters
                 // this is very simple, but one cannot handle CRTL-key combination.

--- a/source/linux/duplicates/Keyboard.cpp
+++ b/source/linux/duplicates/Keyboard.cpp
@@ -37,10 +37,13 @@ void addTextToBuffer(const char *text)
             addKeyToBuffer(0x0d);
             break;
         }
-        case 0x20 ... 0x7e:
+        default:
         {
-            addKeyToBuffer(*text);
-            break;
+            if (*text >= 0x20 && *text <= 0x7e)
+            {
+                addKeyToBuffer(*text);
+                break;
+            }
         }
         }
         ++text;

--- a/source/linux/paddle.cpp
+++ b/source/linux/paddle.cpp
@@ -6,6 +6,8 @@
 #include "CPU.h"
 #include "CopyProtectionDongles.h"
 
+#include <cmath>
+
 namespace
 {
     unsigned __int64 g_nJoyCntrResetCycle = 0;       // Abs cycle that joystick counters were reset


### PR DESCRIPTION
Here are a number of fixes that will allow `sa2` to compile cleanly in Visual Studio.
Most of the changes are GCC-specific fixes.
The biggest change is the addition of `getopt.c` and `getopt.h` specifically for Windows builds.

There's also a modification to StdAfx.h which lets CMakeLists disable the speech api when using `sa`2 on Windows.

