### PR TITLE
Fix for keyboard latching

### DIFF
--- a/source/linux/duplicates/Keyboard.cpp
+++ b/source/linux/duplicates/Keyboard.cpp
@@ -153,3 +153,11 @@ BYTE KeybClearStrobe(void)
 	if (keys.empty())
 	{
 		return 0;
+	}
+	else
+	{
+		const BYTE result = keys.front();
+		keys.pop();
+		return result | 0x80;
+	}
+}


### PR DESCRIPTION
Referring to #320 the keystroke latch now gets cleared after a configurable number of accesses if the queue is > 1.
I set it to 5 accesses similar to KEGS.

A new keystroke could always replace an existing one, which is the way a non-GS Apple II functions (a new keystroke always overrides an old one), but that would prohibit copy-pasting. AppleWin itself doesn't have a queue and functions that way.