### PR TITLE
minizip: use 32‑bit file API

### DIFF
--- a/minizip/CMakeLists.txt
+++ b/minizip/CMakeLists.txt
@@ -15,6 +15,11 @@ target_include_directories(minizip INTERFACE
   ${CMAKE_CURRENT_SOURCE_DIR}/..
   )
 
+# use 32‑bit file API to fix Android compilation issue
+target_compile_definitions(minizip PUBLIC
+  -DUSE_FILE32API
+)
+
 target_link_libraries(minizip PUBLIC
   zlib2
   )


### PR DESCRIPTION
Fix [Libretro Android compilation](https://github.com/audetto/AppleWin/issues/253#issuecomment-3617749494).

Should we enable it only for Android ? Using something like 

`if(CMAKE_SYSTEM_NAME STREQUAL "Android")`