### PR TITLE
make CanDoFullSpeed public

### DIFF
--- a/source/frontends/common2/commonframe.h
+++ b/source/frontends/common2/commonframe.h
@@ -35,9 +35,10 @@ namespace common2
 
         void LoadSnapshot() override;
 
+        virtual bool CanDoFullSpeed();
+
     protected:
         virtual void SetFullSpeed(const bool value);
-        virtual bool CanDoFullSpeed();
 
         void ExecuteInRunningMode(const int64_t microseconds);
         void ExecuteInDebugMode(const int64_t microseconds);


### PR DESCRIPTION
...so that the caller can determine whether to let the host CPU rest, or to keep calling Execute() as quickly as possible.

needed for https://github.com/sh95014/AppleWin/issues/76, some discussion in https://github.com/AppleWin/AppleWin/issues/1453