### PR TITLE
Fix MSVC 2019 not linking due to BreakpointCard.cpp missing from Proj…

### DIFF
--- a/AppleWinExpress2019.vcxproj
+++ b/AppleWinExpress2019.vcxproj
@@ -175,6 +175,7 @@
     <ClCompile Include="source\CopyProtectionDongles.cpp" />
     <ClCompile Include="source\Core.cpp" />
     <ClCompile Include="source\CPU.cpp" />
+    <ClCompile Include="source\Debugger\BreakpointCard.cpp" />
     <ClCompile Include="source\Debugger\Debugger_Disassembler.cpp" />
     <ClCompile Include="source\Debugger\Debugger_Win32.cpp" />
     <ClCompile Include="source\Disk2CardManager.cpp" />

--- a/AppleWinExpress2019.vcxproj.filters
+++ b/AppleWinExpress2019.vcxproj.filters
@@ -280,6 +280,9 @@
     <ClCompile Include="source\ProDOS_Utils.cpp">
       <Filter>Source Files\Emulator</Filter>
     </ClCompile>
+    <ClCompile Include="source\Debugger\BreakpointCard.cpp">
+      <Filter>Source Files\Debugger</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="source\CommonVICE\6510core.h">


### PR DESCRIPTION
…ect.