### PR TITLE
add `videorom` CLI option

### DIFF
--- a/source/frontends/common2/argparser.cpp
+++ b/source/frontends/common2/argparser.cpp
@@ -48,6 +48,8 @@ namespace
     constexpr int STATE_FILENAME = 1026;
     constexpr int LOAD_STATE = 1027;
 
+    constexpr int VIDEOROM = 1028;
+
     struct OptionData_t
     {
         const char *name;
@@ -196,6 +198,7 @@ namespace common2
                  {"memclear",                required_argument,    MEM_CLEAR,        "Memory initialization pattern [0..7]"},
                  {"rom",                     required_argument,    ROM,              "Custom 12k/16k ROM"},
                  {"f8rom",                   required_argument,    F8ROM,            "Custom 2k ROM"},
+                 {"videorom",                required_argument,    VIDEOROM,         "Custom Video ROM"},
              }},
             {"Audio",
              {
@@ -359,6 +362,11 @@ namespace common2
             case F8ROM:
             {
                 options.customRomF8 = optarg;
+                break;
+            }
+            case VIDEOROM:
+            {
+                options.customRomVideo = optarg;
                 break;
             }
             case NO_AUDIO:

--- a/source/frontends/common2/programoptions.cpp
+++ b/source/frontends/common2/programoptions.cpp
@@ -9,6 +9,7 @@
 #include "Speaker.h"
 #include "Riff.h"
 #include "CardManager.h"
+#include "Interface.h"
 
 namespace common2
 {
@@ -98,6 +99,20 @@ namespace common2
             {
                 LogFileOutput("Init: Failed to load custom F8 ROM: %s\n", options.customRomF8.c_str());
             }
+        }
+
+        if (!options.customRomVideo.empty())
+        {
+          if (!GetVideo().ReadVideoRomFile(options.customRomVideo.c_str()))
+          {
+            std::string msg = "Failed to load video rom (not found or not exactly 2/4/8/16KiB)";
+            LogFileOutput("%s\n", msg.c_str());
+            GetFrame().FrameMessageBox(msg.c_str(), "AppleWin Error", MB_OK);
+          }
+          else
+          {
+            GetVideo().SetVideoRomRockerSwitch(true);  // Use PAL char set
+          }
         }
 
         if (!options.wavFileSpeaker.empty())

--- a/source/frontends/common2/programoptions.h
+++ b/source/frontends/common2/programoptions.h
@@ -65,6 +65,7 @@ namespace common2
 
         std::string customRomF8;
         std::string customRom;
+        std::string customRomVideo;
 
         bool noAudio = false;
         std::string wavFileSpeaker;


### PR DESCRIPTION
This PR will add `--videorom` option like upstream AppleWin.

usage:

```
sa2 --videorom pigfont.bin
```

<img width="1876" height="1211" alt="applewin_sa2_videorom_pigfont" src="https://github.com/user-attachments/assets/7cbe060a-33df-4c99-ad7f-123d0e17bc01" />

This will close #358 