### PR TITLE
Run tape loading at the correct emulated speed.

### DIFF
--- a/source/linux/cassettetape.cpp
+++ b/source/linux/cassettetape.cpp
@@ -67,8 +67,9 @@ CassetteTape::tape_data_t CassetteTape::getCurrentWave(size_t &pos) const
 {
     if (myBaseCycles)
     {
+        const double clock = Get6502BaseClock();
         const double delta = g_nCumulativeCycles - *myBaseCycles;
-        const double position = delta / g_fCurrentCLK6502 * myFrequency;
+        const double position = delta / clock * myFrequency;
         pos = static_cast<size_t>(position);
 
         if (pos + 1 < myData.size())


### PR DESCRIPTION
Not at the "wall clock" speed, which the user can modify.

Fixes https://github.com/audetto/AppleWin/issues/401