### PR TITLE
libretro: add the Android x86 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -172,6 +172,18 @@ android-x86_64:
     API_LEVEL: 24
     EXTRA_PATH: source/frontends/libretro
 
+# Android 32-bit x86
+android-x86:
+  extends:
+    - .libretro-android-cmake-x86
+    - .core-defs
+  before_script:
+    - export NUMPROC=$(($(nproc)/5))
+  variables:
+    CXXFLAGS: -Wno-deprecated-declarations -Wno-unknown-attributes
+    API_LEVEL: 24
+    EXTRA_PATH: source/frontends/libretro
+
 # iOS
 libretro-build-ios-arm64:
   extends:


### PR DESCRIPTION
After 77c3257 the CI file has armeabi-v7a, arm64-v8a and x86_64; x86 is the one ABI still missing. It builds exactly like the others, so this is the same job with `.libretro-android-cmake-x86`.

Checked all four ABIs against NDK r29 with the same arguments the buildbot uses (`-DBUILD_LIBRETRO=ON -DENABLE_NETWORKING=OFF -G Ninja`, `ANDROID_PLATFORM=android-24`, `ANDROID_STL=c++_static`):

| ABI | result |
|---|---|
| armeabi-v7a | `ELF 32-bit ARM` |
| arm64-v8a | `ELF 64-bit ARM aarch64` |
| x86 | `ELF 32-bit Intel 80386` |
| x86_64 | `ELF 64-bit x86-64` |

Worth knowing separately: the buildbot has not built any of this yet. Its mirror runs the nightly pipelines on a July commit, so only `android-arm64-v8a` exists on the buildbot right now — armeabi-v7a and x86_64 from 77c3257 have never run there either. They should all appear once the mirror catches up with master.